### PR TITLE
Add missing dependency lixml2-dev for R package devtools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rocker/shiny:3.5.1
 
 RUN apt-get update &&\
-   apt-get install libcurl4-openssl-dev libv8-3.14-dev libssl-dev -y &&\
+   apt-get install libcurl4-openssl-dev libv8-3.14-dev libssl-dev libxml2-dev -y &&\
    mkdir -p /var/lib/shiny-server/bookmarks/shiny
 
 


### PR DESCRIPTION
The command
```
R -e "install.packages('devtools', repos='http://cran.rstudio.com')"
```
results in
```Using PKG_LIBS=-lxml2                                                                                                                                                                                       
------------------------- ANTICONF ERROR ---------------------------                                                                                                                                        
Configuration failed because libxml-2.0 was not found. Try installing:                                                                                                                                      
 * deb: libxml2-dev (Debian, Ubuntu, etc)                                                                                                                                                                   
 * rpm: libxml2-devel (Fedora, CentOS, RHEL)                                                                                                                                                                
 * csw: libxml2_dev (Solaris)             
```
Solution:
The container's Debian 9 does not contain libxml2-dev.
After adding it to the dependencies the image builds without errors and the container runs as expected.